### PR TITLE
fix: remove container names for dokploy

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -4,7 +4,6 @@ volumes:
 
 services:
   db:
-    container_name: docstral_db
     image: postgres:17-alpine
     volumes:
       - postgres_data:/var/lib/postgresql/data
@@ -23,7 +22,6 @@ services:
     restart: unless-stopped
 
   redis:
-    container_name: docstral_redis
     image: redis:7-alpine
     volumes:
       - redis_data:/data
@@ -38,7 +36,6 @@ services:
     restart: unless-stopped
 
   server:
-    container_name: docstral_server
     build:
       context: .
       dockerfile: docker/prod/server/Dockerfile
@@ -52,7 +49,6 @@ services:
     restart: unless-stopped
 
   client:
-    container_name: docstral_client
     build:
       context: .
       dockerfile: docker/prod/client/Dockerfile


### PR DESCRIPTION
Dokploy must work without container name